### PR TITLE
Add instructions for using NPM package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geneontology/wc-gocam-viz",
-  "version": "0.0.50-beta.11",
+  "version": "0.0.51",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@geneontology/wc-gocam-viz",
-      "version": "0.0.50-beta.11",
+      "version": "0.0.51",
       "license": "BSD-3",
       "dependencies": {
         "@geneontology/dbxrefs": "^1.0.16",
@@ -57,6 +57,16 @@
       "engines": {
         "node": ">=10.13.0",
         "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@stencil/core": {
@@ -431,6 +441,12 @@
           }
         }
       }
+    },
+    "@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "peer": true
     },
     "@stencil/core": {
       "version": "2.19.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "module": "dist/index.js",
   "es2015": "dist/esm/index.mjs",
   "es2017": "dist/esm/index.mjs",
-  "types": "dist/custom-elements/index.d.ts",
+  "types": "dist/types/components.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "collection:main": "dist/collection/index.js",
   "unpkg": "dist/wc-gocam-viz/wc-gocam-viz.js",

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ This web component allows to visualize GO-CAM from any website and create entity
 
 ### Script tags
 
-For a simple, static website using `<script>` tag is a quick way to get started. For example:
+For a simple, static website using `<script>` tags is a quick way to get started. For example:
 
 ```html
 <html>
@@ -36,6 +36,8 @@ genes/activities.
 
 ### NPM package
 
+#### Installation
+
 To use the web component as part of a larger front-end application that has its
 own bundling process, first install the dependency:
 
@@ -43,7 +45,9 @@ own bundling process, first install the dependency:
 npm install @geneontology/wc-gocam-viz
 ```
 
-Then somewhere near the top level of your application you must define the custom
+#### Registering custom elements
+
+Somewhere near the top level of your application you must define the custom
 components from this package:
 
 ```js
@@ -53,3 +57,44 @@ defineCustomElements()
 ```
 
 Now the `<wc-gocam-viz>` element can be used in your application's markup. 
+
+#### Configuration for image assets
+
+The legend feature of the component requires image assets to be served by your
+application. These assets are distributed in the
+`node_modules/@geneontology/wc-gocam-viz/dist/wc-gocam-viz/assets` directory. If
+your applications uses a bundler you should configure it to automatically copy
+the files in that directory to an `assets` directory in the build ouput.
+
+A webpack configuration that uses the
+[CopyWebpackPlugin](https://webpack.js.org/plugins/copy-webpack-plugin/) to do
+this might look like:
+
+```js
+const path = require('path');
+const CopyPlugin = require('copy-webpack-plugin');
+
+module.exports = {
+  entry: './src/index.js',
+  output: {
+    filename: 'main.js',
+    path: path.resolve(__dirname, 'dist'),
+  },
+  plugins: [
+    new CopyPlugin({
+      patterns: [
+        {
+          from: path.resolve(__dirname, 'node_modules/@geneontology/wc-gocam-viz/dist/wc-gocam-viz/assets'),
+          to: path.resolve(__dirname, 'dist/assets'),
+        },
+      ],
+    }),
+  ],
+};
+```
+
+For other bundlers, consider a similar configuration using one of the following plugins:
+
+* [rollup-plugin-copy](https://github.com/vladshcherbin/rollup-plugin-copy)
+* [vite-plugin-static-copy](https://github.com/sapphi-red/vite-plugin-static-copy)
+* [esbuild-plugin-copy](https://github.com/LinbuduLab/esbuild-plugins/tree/main/packages/esbuild-plugin-copy)

--- a/readme.md
+++ b/readme.md
@@ -6,22 +6,18 @@ This web component allows to visualize GO-CAM from any website and create entity
 
 ## Usage
 
-NPM package: https://www.npmjs.com/package/@geneontology/wc-gocam-viz
+### Script tags
 
-In any HTML page:
-````
+For a simple, static website using `<script>` tag is a quick way to get started. For example:
+
+```html
 <html>
-
-
   <head>
     <script type="module" src="https://unpkg.com/@geneontology/wc-gocam-viz/dist/wc-gocam-viz/wc-gocam-viz.esm.js"></script>
     <script nomodule="" src="https://unpkg.com/@geneontology/wc-gocam-viz/dist/wc-gocam-viz/wc-gocam-viz.js"></script> 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   </head>
-  
-
   <body>
-
     <wc-gocam-viz 
       id="gocam-1"
       gocam-id="568b0f9600000284"
@@ -31,13 +27,29 @@ In any HTML page:
       show-gene-product=true
       show-activity=false
     ></wc-gocam-viz>
-    
   </body>
 </html>
+```
 
+This will render a GO-CAM model highlighting the flow of regulations between
+genes/activities.
 
-````
+### NPM package
 
-This will render a GO-CAM model highlighting the flow of regulations between genes/activities
+To use the web component as part of a larger front-end application that has its
+own bundling process, first install the dependency:
 
-![GO-CAM example](Example.png)
+```shell
+npm install @geneontology/wc-gocam-viz
+```
+
+Then somewhere near the top level of your application you must define the custom
+components from this package:
+
+```js
+import { defineCustomElements } from '@geneontology/wc-gocam-viz/loader'
+
+defineCustomElements()
+```
+
+Now the `<wc-gocam-viz>` element can be used in your application's markup. 

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -22,7 +22,7 @@ export const config: Config = {
       esmLoaderPath: '../loader',
     },
     {
-      type: 'dist-custom-elements-bundle',
+      type: 'dist-custom-elements',
     },
     {
       type: 'docs-readme',


### PR DESCRIPTION
Fixes #13
Fixes #14 

These changes add instructions for using the NPM package to the readme. While getting acquainted with Stencil's build process (to make sure I was adding the right instructions 😁) I noticed that the deprecated `dist-custom-elements-bundle` output type was being used in `stencil.config.js`. I replaced it with [Stencil's recommended replacement](https://stenciljs.com/docs/v2/custom-elements#how-is-this-different-from-the-dist-and-the-dist-custom-element-bundle-output-targets), `dist-custom-elements`.