### PR TITLE
Replace `repository` prop with `apiUrl` prop on `wc-gocam-viz` component

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,6 @@
       <!-- ACTUAL INTEGRATION OF THE GOCAM-VIZ COMPONENT -->
       <wc-gocam-viz
         id="gocam-1"
-        repository='dev'
         gocam-id='568b0f9600000284'
         show-go-cam-selector=true
         show-has-input=false

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -28,13 +28,13 @@ export namespace Components {
     }
     interface WcGocamViz {
         /**
-          * ID of the gocam to be shown in this widget. Look for the watcher below that will load the GO-CAM upon a change of this variable
+          * The url used to fetch GO-CAM graphs. Any occurrence of %ID in the string will be replaced by the GO-CAM ID.
+         */
+        "apiUrl": string;
+        /**
+          * ID of the GO-CAM to be shown in this widget. Look for the watcher below that will load the GO-CAM upon a change of this variable
          */
         "gocamId": string;
-        /**
-          * Used to connect to a barista instance. By default, always access production (prod) server prod = http://barista.berkeleybop.org dev  = http://barista-dev.berkeleybop.org
-         */
-        "repository": string;
         /**
           * Center the cytoscape graph to fit the whole graph
          */
@@ -124,17 +124,17 @@ declare namespace LocalJSX {
     }
     interface WcGocamViz {
         /**
-          * ID of the gocam to be shown in this widget. Look for the watcher below that will load the GO-CAM upon a change of this variable
+          * The url used to fetch GO-CAM graphs. Any occurrence of %ID in the string will be replaced by the GO-CAM ID.
+         */
+        "apiUrl"?: string;
+        /**
+          * ID of the GO-CAM to be shown in this widget. Look for the watcher below that will load the GO-CAM upon a change of this variable
          */
         "gocamId"?: string;
         "onLayoutChange"?: (event: WcGocamVizCustomEvent<any>) => void;
         "onNodeClick"?: (event: WcGocamVizCustomEvent<any>) => void;
         "onNodeOut"?: (event: WcGocamVizCustomEvent<any>) => void;
         "onNodeOver"?: (event: WcGocamVizCustomEvent<any>) => void;
-        /**
-          * Used to connect to a barista instance. By default, always access production (prod) server prod = http://barista.berkeleybop.org dev  = http://barista-dev.berkeleybop.org
-         */
-        "repository"?: string;
         /**
           * Show/hide default legend
          */

--- a/src/components/gocam-viz/gocam-viz.tsx
+++ b/src/components/gocam-viz/gocam-viz.tsx
@@ -41,10 +41,16 @@ export class GoCamViz {
     graphDiv: HTMLDivElement;
 
     /**
-     * ID of the gocam to be shown in this widget. Look for the watcher below that will load
+     * ID of the GO-CAM to be shown in this widget. Look for the watcher below that will load
      * the GO-CAM upon a change of this variable
      */
     @Prop() gocamId: string;
+
+    /**
+     * The url used to fetch GO-CAM graphs. Any occurrence of %ID in the string will be replaced
+     * by the GO-CAM ID.
+     */
+    @Prop() apiUrl: string = "https://api.geneontology.xyz/gocam/%ID/raw";
 
     /**
      * Show/hide default legend
@@ -71,27 +77,6 @@ export class GoCamViz {
     dbXrefsReady = false;       // check if dbxrefs is initialized
 
     /**
-     * Base URL used to fetch gocam as bbop graph
-     */
-    apiUrl = "https://api.geneontology.xyz/gocam/";
-    devBaristaUrl = 'http://barista-dev.berkeleybop.org/search/stored?id=';
-    localDevBaristaUrl = 'http://localhost:3400/search/stored?id=';
-    productionBaristaUrl = 'http://barista.berkeleybop.org/search/stored?id=';
-
-    noctuaGraphURL = {
-        prod: "http://noctua.geneontology.org/editor/graph/",
-        dev: "http://noctua-dev.berkeleybop.org/editor/graph/",
-        release: "http://noctua.geneontology.org/editor/graph/",
-    };
-
-    /**
-     * Used to connect to a barista instance. By default, always access production (prod) server
-     * prod = http://barista.berkeleybop.org
-     * dev  = http://barista-dev.berkeleybop.org
-     */
-    @Prop() repository: string = 'release';
-
-    /**
      * This state is updated whenever loading a new graph, in order to trigger a new rendering of genes-panel
      */
     @State() cam: Cam;
@@ -99,18 +84,6 @@ export class GoCamViz {
     @State() title: string;
 
     @State() expandComplex = false;
-
-    @Watch('repository')
-    changeRepository(newValue, oldValue) {
-        const isNotString = typeof newValue !== 'string';
-        if (isNotString) {
-          throw new Error('repository: not string');
-        }
-        if (newValue !== oldValue) {
-            this.loadGoCam(this.gocamId)
-        }
-    }
-
 
     // Variables for handling click and mouse over
     selectedNode = undefined;
@@ -269,15 +242,16 @@ export class GoCamViz {
     selectGOCAM(event: CustomEvent) {
         if (event.detail) {
             let data = event.detail;
-            this.gocamId = data.id; // this trigger the gocamIdChanged below
+            this.gocamId = data.id; // this trigger the watchGoCamIdAndApiUrl below
         }
     }
 
-    // If the gocam id is changed, update the current graph to the new gocam
+    // If the GO-CAM ID or API URL is changed, update the current graph to the new gocam
     @Watch('gocamId')
-    gocamIdChanged(newValue, oldValue) {
-        if (newValue != oldValue) {
-            this.loadGoCam(newValue);
+    @Watch('apiUrl')
+    watchGoCamIdAndApiUrl(newValue: string, oldValue: string, propName: string) {
+        if (newValue !== oldValue) {
+            this.loadGoCam();
         }
     }
 
@@ -305,32 +279,25 @@ export class GoCamViz {
      * Will request the gocam from the bbop manager; if manager approves, will trigger renderGoCam
      * @param gocamId valid gocam id gomodel:xxx
      */
-    loadGoCam(gocamId) {
+    loadGoCam() {
         this.graphDiv.innerHTML = ""
-        if (!gocamId.startsWith("gomodel:")) {
-            gocamId = "gomodel:" + gocamId;
+
+        let gocamCurie = this.gocamId;
+        if (!gocamCurie.startsWith("gomodel:")) {
+            gocamCurie = "gomodel:" + gocamCurie;
         }
         this.loading = true;
         this.error = false;
         this.cam = undefined;
-        let url = ''
 
-        if (this.repository === 'prod') {
-            url = this.productionBaristaUrl + gocamId;
-        } else if (this.repository === 'dev') {
-            url = this.devBaristaUrl + gocamId;
-        } else if (this.repository === 'local-dev') {
-            url = this.localDevBaristaUrl + gocamId;
-        } else if (this.repository === 'release') {
-            url = this.apiUrl + gocamId + "/raw"
-        }
-
+        const url = this.apiUrl.replace('%ID', gocamCurie);
         fetch(url).then(data => {
             return data.json();
         }).catch(err => {
             console.error("Error while fetching gocam ", url);
         }).then(graph => {
-            let model = (this.repository === 'release') ? graph : graph.activeModel;
+
+            let model = graph.activeModel ?? graph;
             if (model) {
                 this.cam = this.graphService.getCam(model)
                 this.currentGraph = this.cam.graph;
@@ -849,14 +816,7 @@ export class GoCamViz {
      * https://stenciljs.com/docs/component-lifecycle
     */
     componentDidLoad() {
-        this.loadGoCam(this.gocamId);
-    }
-
-    /**
-     * Method to open the current gocam model into noctua
-    */
-    openInNoctua() {
-        window.open(this.noctuaGraphURL[this.repository] + this.currentGraph.id(), "_blank");
+        this.loadGoCam();
     }
 
     /**

--- a/src/components/gocam-viz/readme.md
+++ b/src/components/gocam-viz/readme.md
@@ -7,11 +7,11 @@
 
 ## Properties
 
-| Property     | Attribute     | Description                                                                                                                                                               | Type      | Default     |
-| ------------ | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ----------- |
-| `gocamId`    | `gocam-id`    | ID of the gocam to be shown in this widget. Look for the watcher below that will load the GO-CAM upon a change of this variable                                           | `string`  | `undefined` |
-| `repository` | `repository`  | Used to connect to a barista instance. By default, always access production (prod) server prod = http://barista.berkeleybop.org dev  = http://barista-dev.berkeleybop.org | `string`  | `'release'` |
-| `showLegend` | `show-legend` | Show/hide default legend                                                                                                                                                  | `boolean` | `true`      |
+| Property     | Attribute     | Description                                                                                                                      | Type      | Default                                        |
+| ------------ | ------------- | -------------------------------------------------------------------------------------------------------------------------------- | --------- | ---------------------------------------------- |
+| `apiUrl`     | `api-url`     | The url used to fetch GO-CAM graphs. Any occurrence of %ID in the string will be replaced by the GO-CAM ID.                      | `string`  | `"https://api.geneontology.xyz/gocam/%ID/raw"` |
+| `gocamId`    | `gocam-id`    | ID of the GO-CAM to be shown in this widget. Look for the watcher below that will load the GO-CAM upon a change of this variable | `string`  | `undefined`                                    |
+| `showLegend` | `show-legend` | Show/hide default legend                                                                                                         | `boolean` | `true`                                         |
 
 
 ## Events

--- a/src/index.html
+++ b/src/index.html
@@ -16,19 +16,6 @@
 <body>
 
   <div style='max-width: 1200px; margin: 0 auto'>
-    <div style='margin-bottom: 1rem'>
-      <label for='goc-repository-select'>Select Repository:</label>
-      <select name='repository' id='goc-repository-select'>
-        <option value='prod'>Noctua Production</option>
-        <option value='dev'>Noctua Development(for developers only)</option>
-      </select>
-    </div>
-
-    <!-- ACTUAL INTEGRATION OF THE GOCAM-VIZ COMPONENT ex gomodel:56d1143000000176 gomodel:6202e3b700000172 localgomodel:61f34dd300001044-->
-    <!--<wc-gocam-viz id="gocam-1" repository="local-dev" gocam-id="63bbb65600000000" show-go-cam-selector=true
-      show-has-input=true show-has-output=true show-gene-product=true show-activity=true show-isolated-activity=true>
-    </wc-gocam-viz>-->
-
     <wc-gocam-viz
       id='gocam-1'
       gocam-id='568b0f9600000284'
@@ -43,30 +30,8 @@
     </wc-gocam-viz>
   </div>
 
-  <!-- <wc-gocam-viz
-      id="gocam-1"
-      repository="dev"
-      gocam-id="gomodel:YEAST-SALV-PYRMID-DNTP"
-      show-go-cam-selector=true
-      show-has-input=false
-      show-has-output=false
-      show-gene-product=true
-      show-activity=false
-      show-isolated-activity=true
-    ></wc-gocam-viz> -->
-
-
   <!-- OPTIONAL: SPECIAL HANDLING OF EVENTS -->
   <script>
-
-    var repositorySelect = document.getElementById('goc-repository-select');
-    repositorySelect.addEventListener('change', updateRepository);
-
-    function updateRepository(e) {
-      var goCamViz = document.getElementById('gocam-1');
-      goCamViz.setAttribute('repository', e.target.value);
-    }
-
     /**
      * General Key listener, here to recenter the graph visualization
      */

--- a/src/styled.html
+++ b/src/styled.html
@@ -57,14 +57,6 @@
 <body>
 
   <div style='max-width: 1200px; margin: 0 auto'>
-    <div style='margin-bottom: 1rem'>
-      <label for='goc-repository-select'>Select Repository:</label>
-      <select name='repository' id='goc-repository-select'>
-        <option value='prod'>Noctua Production</option>
-        <option value='dev'>Noctua Development(for developers only)</option>
-      </select>
-    </div>
-
     <wc-gocam-viz
       id='gocam-1'
       gocam-id='568b0f9600000284'
@@ -82,15 +74,6 @@
 
   <!-- OPTIONAL: SPECIAL HANDLING OF EVENTS -->
   <script>
-
-    var repositorySelect = document.getElementById('goc-repository-select');
-    repositorySelect.addEventListener('change', updateRepository);
-
-    function updateRepository(e) {
-      var goCamViz = document.getElementById('gocam-1');
-      goCamViz.setAttribute('repository', e.target.value);
-    }
-
     /**
      * General Key listener, here to recenter the graph visualization
      */


### PR DESCRIPTION
Marking this as a draft for now while we decide how quickly the current `api.geneontology.xyz` endpoint can be recreated on `api.geneontology.org`

---

Fixes #25 

Currently the `wc-gocam-viz` component has a `repository` prop which accepts an enum-like set of strings. Based on the value it builds different URLs to fetch the GO-CAM model. These included an endpoint on `api.geneontology.xyz` as the default, a couple of Barista endpoints (which we don't want to use at all anymore), and a `localhost` endpoint which would only be useful for certain local development scenarios.

With these changes the `release` prop is removed and a new `apiUrl` prop is added. The default is the `api.geneontology.xyz` endpoint. Since changing the API endpoint should be a fairly rare use case I've also removed the select box from the dev/demo pages. If you needed to point the widget to a local endpoint for development, you'd temporarily change the dev/demo page by adding the appropriate attribute (e.g. `api-url='http://localhost/path/to/endpoint/%ID`) to the `wc-gocam-viz` element.