### PR TITLE
Add GitHub workflows for testing and publishing

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing
+
+## Development
+
+### Getting started
+
+1. Ensure you have a recent version of Node.js installed. Using [nvm](https://github.com/nvm-sh/nvm) makes this easy.
+2. These components are built with Stencil. If you're not already familiar with Stencil, review its [docs](https://stenciljs.com/docs/introduction) to learn about the core concepts.
+
+### Making changes
+
+1. Install dependencies with `npm install` if you're starting from scratch or if the `package-lock.json` file has changed since the last time it was run.
+2. Start the development server with `npm start`. As you make changes to components the changes will automatically reload in the browser. The main host page for development is `src/index.html`. Pages for testing individual components can be added to the respective component directory (e.g. `src/components/gocam-legend/index.html`)
+3. Use `npm run build` to build the project. This will also update auto-generated files if necessary. These changes should be reviewed and committed with the rest of your changes.
+
+### Publishing releases
+
+1. Use `npm version` to increment the version number followed by `git push && git push --tags` to push the version change to GitHub.
+2. Create a new GitHub [release](https://github.com/geneontology/wc-gocam-viz/releases) using the new version tag. Once the new release is created, a GitHub Action will automatically publish it to NPM.

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,0 +1,36 @@
+name: Build and test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        run: npm run build
+
+      - name: Check diff
+        # Take from https://github.com/ionic-team/ionic-framework/blob/c801e2ada9d1f36bbb8ed58d814afae94510e304/.github/workflows/actions/test-core-clean-build/action.yml
+        run: |
+          git diff --exit-code || {
+            echo -e "\033[1;31m⚠️ Error: Differences Detected ⚠️\033[0m"
+            echo -e "\033[1;31mThere are uncommitted changes between the build outputs from CI and your branch.\033[0m"
+            echo -e "\033[1;31mPlease ensure you have followed these steps:\033[0m"
+            echo -e "\033[1;31m1. Run 'npm run build' locally to generate the latest build output.\033[0m"
+            echo -e "\033[1;31m2. Commit and push all necessary changes to your branch.\033[0m"
+            echo -e "\033[1;31m3. Compare and validate the differences before proceeding.\033[0m"
+            exit 1
+          }

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -10,7 +10,7 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -1,0 +1,28 @@
+name: Publish release
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        run: npm run build
+
+      - name: Publish to NPM
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Fixes #15 

These changes add GitHub workflows to do some basic sanity checks on PRs and publishing to NPM when GitHub releases are made. I also added a quick `CONTRIBUTING.md` to outline the development and release process.