### PR TITLE
Allow GO-CAM data to be provided to widget

### DIFF
--- a/advanced-example.html
+++ b/advanced-example.html
@@ -10,14 +10,10 @@
     <div id="gocam-viz-container"></div>
 
     <script>
-        async function loadGOCAM(gocam) {
+        async function loadGOCAM() {
             // create the gocam viz element
             var element = await document.createElement("wc-gocam-viz");
             element.setAttribute("gocam-id", gocamId);
-            element.setAttribute("show-has-input", "false");
-            element.setAttribute("show-has-output", "false");
-            element.setAttribute("show-activity", "false");
-            element.setAttribute("show-gene-product", "true");            
             await document.getElementById("gocam-viz-container").appendChild(element);
         }
 

--- a/basic-example.html
+++ b/basic-example.html
@@ -14,8 +14,7 @@
 
 
   <!-- ACTUAL INTEGRATION OF THE GOCAM-VIZ COMPONENT 568b0f9600000284-->
-  <wc-gocam-viz id="gocam-1" gocam-id="62b4ffe300003754" show-go-cam-selector=true show-has-input=false
-    show-has-output=false show-gene-product=true show-activity=false></wc-gocam-viz>
+  <wc-gocam-viz id="gocam-1" gocam-id="62b4ffe300003754"></wc-gocam-viz>
 
 
   <!-- OPTIONAL: SPECIAL HANDLING OF EVENTS -->

--- a/index.html
+++ b/index.html
@@ -19,11 +19,6 @@
       <wc-gocam-viz
         id="gocam-1"
         gocam-id='568b0f9600000284'
-        show-go-cam-selector=true
-        show-has-input=false
-        show-has-output=false
-        show-gene-product=true
-        show-activity=false
       ></wc-gocam-viz>
 
 

--- a/readme.md
+++ b/readme.md
@@ -21,11 +21,6 @@ For a simple, static website using `<script>` tags is a quick way to get started
     <wc-gocam-viz 
       id="gocam-1"
       gocam-id="568b0f9600000284"
-      show-go-cam-selector=true
-      show-has-input=false
-      show-has-output=false
-      show-gene-product=true
-      show-activity=false
     ></wc-gocam-viz>
   </body>
 </html>

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -32,7 +32,7 @@ export namespace Components {
          */
         "apiUrl": string;
         /**
-          * ID of the GO-CAM to be shown in this widget. Look for the watcher below that will load the GO-CAM upon a change of this variable
+          * ID of the GO-CAM to be shown in this widget. If provided, the GO-CAM will automatically be fetched using this ID and the value of the `api-url` prop. If omitted, data will not automatically be fetched, but can be provided via the `setModelData` method. This may be useful if the host page already has the GO-CAM data.
          */
         "gocamId": string;
         /**
@@ -44,6 +44,11 @@ export namespace Components {
           * @param shouldAF set to true if you want a mouse scroll to be captured by the component
          */
         "setAutoFocus": (shouldAF: any) => Promise<void>;
+        /**
+          * Manually supply GO-CAM data to be rendered. This will overwrite any data previously fetched using the gocamId and apiUrl props, if they were provided.
+          * @param model GO-CAM object
+         */
+        "setModelData": (model: any) => Promise<void>;
         /**
           * Show/hide default legend
          */
@@ -128,7 +133,7 @@ declare namespace LocalJSX {
          */
         "apiUrl"?: string;
         /**
-          * ID of the GO-CAM to be shown in this widget. Look for the watcher below that will load the GO-CAM upon a change of this variable
+          * ID of the GO-CAM to be shown in this widget. If provided, the GO-CAM will automatically be fetched using this ID and the value of the `api-url` prop. If omitted, data will not automatically be fetched, but can be provided via the `setModelData` method. This may be useful if the host page already has the GO-CAM data.
          */
         "gocamId"?: string;
         "onLayoutChange"?: (event: WcGocamVizCustomEvent<any>) => void;

--- a/src/components/gocam-viz/readme.md
+++ b/src/components/gocam-viz/readme.md
@@ -7,11 +7,11 @@
 
 ## Properties
 
-| Property     | Attribute     | Description                                                                                                                      | Type      | Default                                         |
-| ------------ | ------------- | -------------------------------------------------------------------------------------------------------------------------------- | --------- | ----------------------------------------------- |
-| `apiUrl`     | `api-url`     | The url used to fetch GO-CAM graphs. Any occurrence of %ID in the string will be replaced by the GO-CAM ID.                      | `string`  | `"https://api.geneontology.org/api/go-cam/%ID"` |
-| `gocamId`    | `gocam-id`    | ID of the GO-CAM to be shown in this widget. Look for the watcher below that will load the GO-CAM upon a change of this variable | `string`  | `undefined`                                     |
-| `showLegend` | `show-legend` | Show/hide default legend                                                                                                         | `boolean` | `true`                                          |
+| Property     | Attribute     | Description                                                                                                                                                                                                                                                                                                                   | Type      | Default                                         |
+| ------------ | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ----------------------------------------------- |
+| `apiUrl`     | `api-url`     | The url used to fetch GO-CAM graphs. Any occurrence of %ID in the string will be replaced by the GO-CAM ID.                                                                                                                                                                                                                   | `string`  | `"https://api.geneontology.org/api/go-cam/%ID"` |
+| `gocamId`    | `gocam-id`    | ID of the GO-CAM to be shown in this widget. If provided, the GO-CAM will automatically be fetched using this ID and the value of the `api-url` prop. If omitted, data will not automatically be fetched, but can be provided via the `setModelData` method. This may be useful if the host page already has the GO-CAM data. | `string`  | `undefined`                                     |
+| `showLegend` | `show-legend` | Show/hide default legend                                                                                                                                                                                                                                                                                                      | `boolean` | `true`                                          |
 
 
 ## Events
@@ -39,6 +39,17 @@ Type: `Promise<void>`
 ### `setAutoFocus(shouldAF: any) => Promise<void>`
 
 Define if the GO-CAM viz should capture the mouse scroll
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+### `setModelData(model: any) => Promise<void>`
+
+Manually supply GO-CAM data to be rendered. This will overwrite any data previously
+fetched using the gocamId and apiUrl props, if they were provided.
 
 #### Returns
 

--- a/src/index.html
+++ b/src/index.html
@@ -19,12 +19,6 @@
     <wc-gocam-viz
       id='gocam-1'
       gocam-id='568b0f9600000284'
-      show-go-cam-selector='true'
-      show-has-input='true'
-      show-has-output='true'
-      show-gene-product='true'
-      show-activity='true'
-      show-isolated-activity='true'
       show-legend='true'
     >
     </wc-gocam-viz>

--- a/src/local-data.html
+++ b/src/local-data.html
@@ -1,0 +1,1139 @@
+<html dir='ltr' lang='en'>
+
+
+<head>
+  <meta name='viewport' content='width=device-width, initial-scale=1' />
+  <script type='module' src='/build/wc-gocam-viz.esm.js'></script>
+  <script nomodule src='/build/wc-gocam-viz.js'></script>
+
+  <link rel='stylesheet'
+        href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css'>
+  <link rel='stylesheet' href='/reset.css'>
+  <title>wc-gocam-viz</title>
+</head>
+
+
+<body>
+
+  <div style='max-width: 1200px; margin: 0 auto'>
+    <wc-gocam-viz id='gocam-1'></wc-gocam-viz>
+  </div>
+
+  <script id='data' type='application/json'>
+    {
+      "id": "gomodel:6197061700003523",
+      "individuals": [
+        {
+          "id": "gomodel:6197061700003523/61e0e55600000067",
+          "type": [
+            {
+              "type": "class",
+              "id": "GO:0005615",
+              "label": "extracellular space"
+            }
+          ],
+          "root-type": [
+            {
+              "type": "class",
+              "id": "UBERON:0001062",
+              "label": "anatomical entity"
+            },
+            {
+              "type": "class",
+              "id": "GO:0110165",
+              "label": "cellular anatomical entity"
+            },
+            {
+              "type": "class",
+              "id": "GO:0005575",
+              "label": "cellular_component"
+            },
+            {
+              "type": "class",
+              "id": "CARO:0000000",
+              "label": "anatomical entity"
+            }
+          ],
+          "annotations": [
+            {
+              "key": "date",
+              "value": "2022-01-14"
+            },
+            {
+              "key": "providedBy",
+              "value": "http://informatics.jax.org"
+            },
+            {
+              "key": "contributor",
+              "value": "https://orcid.org/0000-0001-7476-6306"
+            }
+          ]
+        },
+        {
+          "id": "gomodel:6197061700003523/61e0e55600000068",
+          "type": [
+            {
+              "type": "class",
+              "id": "ECO:0000266",
+              "label": "sequence orthology evidence used in manual assertion"
+            }
+          ],
+          "root-type": [
+            {
+              "type": "class",
+              "id": "ECO:0000000",
+              "label": "evidence"
+            }
+          ],
+          "annotations": [
+            {
+              "key": "date",
+              "value": "2022-01-14"
+            },
+            {
+              "key": "providedBy",
+              "value": "http://informatics.jax.org"
+            },
+            {
+              "key": "with",
+              "value": "UniProtKB:Q02297"
+            },
+            {
+              "key": "source",
+              "value": "PMID:8702723"
+            },
+            {
+              "key": "contributor",
+              "value": "https://orcid.org/0000-0001-7476-6306"
+            }
+          ]
+        },
+        {
+          "id": "gomodel:6197061700003523/6197061700003524",
+          "type": [
+            {
+              "type": "class",
+              "id": "MGI:MGI:95411",
+              "label": "Erbb3 Mmus"
+            }
+          ],
+          "root-type": [
+            {
+              "type": "class",
+              "id": "CHEBI:33695",
+              "label": "information biomacromolecule"
+            },
+            {
+              "type": "class",
+              "id": "CHEBI:24431",
+              "label": "chemical entity"
+            }
+          ],
+          "annotations": [
+            {
+              "key": "providedBy",
+              "value": "http://informatics.jax.org"
+            },
+            {
+              "key": "date",
+              "value": "2021-12-08"
+            },
+            {
+              "key": "contributor",
+              "value": "https://orcid.org/0000-0001-7476-6306"
+            }
+          ]
+        },
+        {
+          "id": "gomodel:6197061700003523/6197061700003525",
+          "type": [
+            {
+              "type": "class",
+              "id": "GO:0038023",
+              "label": "signaling receptor activity"
+            }
+          ],
+          "root-type": [
+            {
+              "type": "class",
+              "id": "GO:0003674",
+              "label": "molecular_function"
+            },
+            {
+              "type": "class",
+              "id": "obo:go/extensions/reacto.owl#molecular_event",
+              "label": "Molecular Event"
+            }
+          ],
+          "annotations": [
+            {
+              "key": "date",
+              "value": "2022-01-14"
+            },
+            {
+              "key": "providedBy",
+              "value": "http://informatics.jax.org"
+            },
+            {
+              "key": "hint-layout-y",
+              "value": "218.25"
+            },
+            {
+              "key": "hint-layout-x",
+              "value": "779"
+            },
+            {
+              "key": "contributor",
+              "value": "https://orcid.org/0000-0001-7476-6306"
+            }
+          ]
+        },
+        {
+          "id": "gomodel:6197061700003523/6197061700003526",
+          "type": [
+            {
+              "type": "class",
+              "id": "GO:0038133",
+              "label": "ERBB2-ERBB3 signaling pathway"
+            }
+          ],
+          "root-type": [
+            {
+              "type": "class",
+              "id": "GO:0008150",
+              "label": "biological_process"
+            }
+          ],
+          "annotations": [
+            {
+              "key": "date",
+              "value": "2022-01-14"
+            },
+            {
+              "key": "contributor",
+              "value": "https://orcid.org/0000-0001-7476-6306"
+            },
+            {
+              "key": "hint-layout-x",
+              "value": "725"
+            },
+            {
+              "key": "providedBy",
+              "value": "http://informatics.jax.org"
+            }
+          ]
+        },
+        {
+          "id": "gomodel:6197061700003523/6197061700003527",
+          "type": [
+            {
+              "type": "class",
+              "id": "GO:0005886",
+              "label": "plasma membrane"
+            }
+          ],
+          "root-type": [
+            {
+              "type": "class",
+              "id": "UBERON:0001062",
+              "label": "anatomical entity"
+            },
+            {
+              "type": "class",
+              "id": "GO:0110165",
+              "label": "cellular anatomical entity"
+            },
+            {
+              "type": "class",
+              "id": "GO:0005575",
+              "label": "cellular_component"
+            },
+            {
+              "type": "class",
+              "id": "CARO:0000000",
+              "label": "anatomical entity"
+            }
+          ],
+          "annotations": [
+            {
+              "key": "hint-layout-x",
+              "value": "773.25"
+            },
+            {
+              "key": "contributor",
+              "value": "https://orcid.org/0000-0001-7476-6306"
+            },
+            {
+              "key": "comment",
+              "value": "Automated change 2022-09-22: GO:0044214 replaced by GO:0005886"
+            },
+            {
+              "key": "providedBy",
+              "value": "http://informatics.jax.org"
+            },
+            {
+              "key": "hint-layout-y",
+              "value": "512"
+            },
+            {
+              "key": "date",
+              "value": "2022-09-22"
+            }
+          ]
+        },
+        {
+          "id": "gomodel:6197061700003523/6197061700003528",
+          "type": [
+            {
+              "type": "class",
+              "id": "MGI:MGI:96083",
+              "label": "Nrg1 Mmus"
+            }
+          ],
+          "root-type": [
+            {
+              "type": "class",
+              "id": "CHEBI:33695",
+              "label": "information biomacromolecule"
+            },
+            {
+              "type": "class",
+              "id": "CHEBI:24431",
+              "label": "chemical entity"
+            }
+          ],
+          "annotations": [
+            {
+              "key": "date",
+              "value": "2021-12-08"
+            },
+            {
+              "key": "providedBy",
+              "value": "http://informatics.jax.org"
+            },
+            {
+              "key": "contributor",
+              "value": "https://orcid.org/0000-0001-7476-6306"
+            }
+          ]
+        },
+        {
+          "id": "gomodel:6197061700003523/6197061700003529",
+          "type": [
+            {
+              "type": "class",
+              "id": "GO:0048018",
+              "label": "receptor ligand activity"
+            }
+          ],
+          "root-type": [
+            {
+              "type": "class",
+              "id": "GO:0003674",
+              "label": "molecular_function"
+            },
+            {
+              "type": "class",
+              "id": "obo:go/extensions/reacto.owl#molecular_event",
+              "label": "Molecular Event"
+            }
+          ],
+          "annotations": [
+            {
+              "key": "contributor",
+              "value": "https://orcid.org/0000-0001-7476-6306"
+            },
+            {
+              "key": "hint-layout-x",
+              "value": "369"
+            },
+            {
+              "key": "providedBy",
+              "value": "http://informatics.jax.org"
+            },
+            {
+              "key": "hint-layout-y",
+              "value": "229"
+            },
+            {
+              "key": "date",
+              "value": "2021-12-08"
+            }
+          ]
+        },
+        {
+          "id": "gomodel:6197061700003523/6197061700003530",
+          "type": [
+            {
+              "type": "class",
+              "id": "MGI:MGI:95410",
+              "label": "Erbb2 Mmus"
+            }
+          ],
+          "root-type": [
+            {
+              "type": "class",
+              "id": "CHEBI:33695",
+              "label": "information biomacromolecule"
+            },
+            {
+              "type": "class",
+              "id": "CHEBI:24431",
+              "label": "chemical entity"
+            }
+          ],
+          "annotations": [
+            {
+              "key": "providedBy",
+              "value": "http://informatics.jax.org"
+            },
+            {
+              "key": "date",
+              "value": "2021-12-08"
+            },
+            {
+              "key": "contributor",
+              "value": "https://orcid.org/0000-0001-7476-6306"
+            }
+          ]
+        },
+        {
+          "id": "gomodel:6197061700003523/6197061700003531",
+          "type": [
+            {
+              "type": "class",
+              "id": "GO:0004713",
+              "label": "protein tyrosine kinase activity"
+            }
+          ],
+          "root-type": [
+            {
+              "type": "class",
+              "id": "GO:0003674",
+              "label": "molecular_function"
+            },
+            {
+              "type": "class",
+              "id": "obo:go/extensions/reacto.owl#molecular_event",
+              "label": "Molecular Event"
+            }
+          ],
+          "annotations": [
+            {
+              "key": "date",
+              "value": "2021-12-08"
+            },
+            {
+              "key": "hint-layout-y",
+              "value": "230"
+            },
+            {
+              "key": "providedBy",
+              "value": "http://informatics.jax.org"
+            },
+            {
+              "key": "hint-layout-x",
+              "value": "1151"
+            },
+            {
+              "key": "contributor",
+              "value": "https://orcid.org/0000-0001-7476-6306"
+            }
+          ]
+        },
+        {
+          "id": "gomodel:6197061700003523/6197061700003532",
+          "type": [
+            {
+              "type": "class",
+              "id": "ECO:0000266",
+              "label": "sequence orthology evidence used in manual assertion"
+            }
+          ],
+          "root-type": [
+            {
+              "type": "class",
+              "id": "ECO:0000000",
+              "label": "evidence"
+            }
+          ],
+          "annotations": [
+            {
+              "key": "providedBy",
+              "value": "http://informatics.jax.org"
+            },
+            {
+              "key": "with",
+              "value": "UniProtKB:Q02297"
+            },
+            {
+              "key": "source",
+              "value": "PMID:8702723"
+            },
+            {
+              "key": "date",
+              "value": "2021-12-08"
+            },
+            {
+              "key": "contributor",
+              "value": "https://orcid.org/0000-0001-7476-6306"
+            }
+          ]
+        },
+        {
+          "id": "gomodel:6197061700003523/6197061700003533",
+          "type": [
+            {
+              "type": "class",
+              "id": "ECO:0000266",
+              "label": "sequence orthology evidence used in manual assertion"
+            }
+          ],
+          "root-type": [
+            {
+              "type": "class",
+              "id": "ECO:0000000",
+              "label": "evidence"
+            }
+          ],
+          "annotations": [
+            {
+              "key": "source",
+              "value": "PMID:8702723"
+            },
+            {
+              "key": "providedBy",
+              "value": "http://informatics.jax.org"
+            },
+            {
+              "key": "with",
+              "value": "UniProtKB:Q02297"
+            },
+            {
+              "key": "contributor",
+              "value": "https://orcid.org/0000-0001-7476-6306"
+            },
+            {
+              "key": "date",
+              "value": "2021-12-08"
+            }
+          ]
+        },
+        {
+          "id": "gomodel:6197061700003523/6197061700003534",
+          "type": [
+            {
+              "type": "class",
+              "id": "ECO:0000266",
+              "label": "sequence orthology evidence used in manual assertion"
+            }
+          ],
+          "root-type": [
+            {
+              "type": "class",
+              "id": "ECO:0000000",
+              "label": "evidence"
+            }
+          ],
+          "annotations": [
+            {
+              "key": "with",
+              "value": "UniProtKB:Q02297"
+            },
+            {
+              "key": "source",
+              "value": "PMID:8702723"
+            },
+            {
+              "key": "providedBy",
+              "value": "http://informatics.jax.org"
+            },
+            {
+              "key": "contributor",
+              "value": "https://orcid.org/0000-0001-7476-6306"
+            },
+            {
+              "key": "date",
+              "value": "2021-12-08"
+            }
+          ]
+        },
+        {
+          "id": "gomodel:6197061700003523/6197061700003536",
+          "type": [
+            {
+              "type": "class",
+              "id": "ECO:0000314",
+              "label": "direct assay evidence used in manual assertion"
+            }
+          ],
+          "root-type": [
+            {
+              "type": "class",
+              "id": "ECO:0000000",
+              "label": "evidence"
+            }
+          ],
+          "annotations": [
+            {
+              "key": "source",
+              "value": "PMID:8702723"
+            },
+            {
+              "key": "providedBy",
+              "value": "http://informatics.jax.org"
+            },
+            {
+              "key": "contributor",
+              "value": "https://orcid.org/0000-0001-7476-6306"
+            },
+            {
+              "key": "date",
+              "value": "2021-12-08"
+            }
+          ]
+        },
+        {
+          "id": "gomodel:6197061700003523/6197061700003537",
+          "type": [
+            {
+              "type": "class",
+              "id": "ECO:0000314",
+              "label": "direct assay evidence used in manual assertion"
+            }
+          ],
+          "root-type": [
+            {
+              "type": "class",
+              "id": "ECO:0000000",
+              "label": "evidence"
+            }
+          ],
+          "annotations": [
+            {
+              "key": "contributor",
+              "value": "https://orcid.org/0000-0001-7476-6306"
+            },
+            {
+              "key": "providedBy",
+              "value": "http://informatics.jax.org"
+            },
+            {
+              "key": "date",
+              "value": "2021-12-08"
+            },
+            {
+              "key": "source",
+              "value": "PMID:8702723"
+            }
+          ]
+        },
+        {
+          "id": "gomodel:6197061700003523/6197061700003538",
+          "type": [
+            {
+              "type": "class",
+              "id": "ECO:0000314",
+              "label": "direct assay evidence used in manual assertion"
+            }
+          ],
+          "root-type": [
+            {
+              "type": "class",
+              "id": "ECO:0000000",
+              "label": "evidence"
+            }
+          ],
+          "annotations": [
+            {
+              "key": "contributor",
+              "value": "https://orcid.org/0000-0001-7476-6306"
+            },
+            {
+              "key": "providedBy",
+              "value": "http://informatics.jax.org"
+            },
+            {
+              "key": "source",
+              "value": "PMID:8702723"
+            },
+            {
+              "key": "date",
+              "value": "2021-12-08"
+            }
+          ]
+        },
+        {
+          "id": "gomodel:6197061700003523/6197061700003539",
+          "type": [
+            {
+              "type": "class",
+              "id": "ECO:0000314",
+              "label": "direct assay evidence used in manual assertion"
+            }
+          ],
+          "root-type": [
+            {
+              "type": "class",
+              "id": "ECO:0000000",
+              "label": "evidence"
+            }
+          ],
+          "annotations": [
+            {
+              "key": "providedBy",
+              "value": "http://informatics.jax.org"
+            },
+            {
+              "key": "contributor",
+              "value": "https://orcid.org/0000-0001-7476-6306"
+            },
+            {
+              "key": "source",
+              "value": "PMID:8702723"
+            },
+            {
+              "key": "date",
+              "value": "2021-12-08"
+            }
+          ]
+        },
+        {
+          "id": "gomodel:6197061700003523/6197061700003540",
+          "type": [
+            {
+              "type": "class",
+              "id": "ECO:0000314",
+              "label": "direct assay evidence used in manual assertion"
+            }
+          ],
+          "root-type": [
+            {
+              "type": "class",
+              "id": "ECO:0000000",
+              "label": "evidence"
+            }
+          ],
+          "annotations": [
+            {
+              "key": "providedBy",
+              "value": "http://informatics.jax.org"
+            },
+            {
+              "key": "contributor",
+              "value": "https://orcid.org/0000-0001-7476-6306"
+            },
+            {
+              "key": "date",
+              "value": "2021-12-08"
+            },
+            {
+              "key": "source",
+              "value": "PMID:8702723"
+            }
+          ]
+        },
+        {
+          "id": "gomodel:6197061700003523/6197061700003541",
+          "type": [
+            {
+              "type": "class",
+              "id": "ECO:0000314",
+              "label": "direct assay evidence used in manual assertion"
+            }
+          ],
+          "root-type": [
+            {
+              "type": "class",
+              "id": "ECO:0000000",
+              "label": "evidence"
+            }
+          ],
+          "annotations": [
+            {
+              "key": "providedBy",
+              "value": "http://informatics.jax.org"
+            },
+            {
+              "key": "date",
+              "value": "2021-12-08"
+            },
+            {
+              "key": "contributor",
+              "value": "https://orcid.org/0000-0001-7476-6306"
+            },
+            {
+              "key": "source",
+              "value": "PMID:8702723"
+            }
+          ]
+        },
+        {
+          "id": "gomodel:6197061700003523/6197061700003542",
+          "type": [
+            {
+              "type": "class",
+              "id": "ECO:0000314",
+              "label": "direct assay evidence used in manual assertion"
+            }
+          ],
+          "root-type": [
+            {
+              "type": "class",
+              "id": "ECO:0000000",
+              "label": "evidence"
+            }
+          ],
+          "annotations": [
+            {
+              "key": "date",
+              "value": "2021-12-08"
+            },
+            {
+              "key": "contributor",
+              "value": "https://orcid.org/0000-0001-7476-6306"
+            },
+            {
+              "key": "providedBy",
+              "value": "http://informatics.jax.org"
+            },
+            {
+              "key": "source",
+              "value": "PMID:8702723"
+            }
+          ]
+        }
+      ],
+      "facts": [
+        {
+          "subject": "gomodel:6197061700003523/6197061700003529",
+          "property": "RO:0002333",
+          "property-label": "RO:0002333",
+          "object": "gomodel:6197061700003523/6197061700003528",
+          "annotations": [
+            {
+              "key": "evidence",
+              "value": "gomodel:6197061700003523/6197061700003532",
+              "value-type": "IRI"
+            },
+            {
+              "key": "contributor",
+              "value": "https://orcid.org/0000-0001-7476-6306"
+            },
+            {
+              "key": "date",
+              "value": "2021-12-08"
+            },
+            {
+              "key": "providedBy",
+              "value": "http://informatics.jax.org"
+            }
+          ]
+        },
+        {
+          "subject": "gomodel:6197061700003523/6197061700003531",
+          "property": "BFO:0000066",
+          "property-label": "BFO:0000066",
+          "object": "gomodel:6197061700003523/6197061700003527",
+          "annotations": [
+            {
+              "key": "evidence",
+              "value": "gomodel:6197061700003523/6197061700003541",
+              "value-type": "IRI"
+            },
+            {
+              "key": "contributor",
+              "value": "https://orcid.org/0000-0001-7476-6306"
+            },
+            {
+              "key": "date",
+              "value": "2021-12-08"
+            },
+            {
+              "key": "providedBy",
+              "value": "http://informatics.jax.org"
+            }
+          ]
+        },
+        {
+          "subject": "gomodel:6197061700003523/6197061700003525",
+          "property": "RO:0002333",
+          "property-label": "RO:0002333",
+          "object": "gomodel:6197061700003523/6197061700003524",
+          "annotations": [
+            {
+              "key": "evidence",
+              "value": "gomodel:6197061700003523/6197061700003536",
+              "value-type": "IRI"
+            },
+            {
+              "key": "contributor",
+              "value": "https://orcid.org/0000-0001-7476-6306"
+            },
+            {
+              "key": "date",
+              "value": "2021-12-08"
+            },
+            {
+              "key": "providedBy",
+              "value": "http://informatics.jax.org"
+            }
+          ]
+        },
+        {
+          "subject": "gomodel:6197061700003523/6197061700003529",
+          "property": "BFO:0000066",
+          "property-label": "BFO:0000066",
+          "object": "gomodel:6197061700003523/61e0e55600000067",
+          "annotations": [
+            {
+              "key": "evidence",
+              "value": "gomodel:6197061700003523/61e0e55600000068",
+              "value-type": "IRI"
+            },
+            {
+              "key": "contributor",
+              "value": "https://orcid.org/0000-0001-7476-6306"
+            },
+            {
+              "key": "date",
+              "value": "2022-01-14"
+            },
+            {
+              "key": "providedBy",
+              "value": "http://informatics.jax.org"
+            }
+          ]
+        },
+        {
+          "subject": "gomodel:6197061700003523/6197061700003529",
+          "property": "BFO:0000050",
+          "property-label": "BFO:0000050",
+          "object": "gomodel:6197061700003523/6197061700003526",
+          "annotations": [
+            {
+              "key": "evidence",
+              "value": "gomodel:6197061700003523/6197061700003533",
+              "value-type": "IRI"
+            },
+            {
+              "key": "contributor",
+              "value": "https://orcid.org/0000-0001-7476-6306"
+            },
+            {
+              "key": "date",
+              "value": "2021-12-08"
+            },
+            {
+              "key": "providedBy",
+              "value": "http://informatics.jax.org"
+            }
+          ]
+        },
+        {
+          "subject": "gomodel:6197061700003523/6197061700003525",
+          "property": "BFO:0000050",
+          "property-label": "BFO:0000050",
+          "object": "gomodel:6197061700003523/6197061700003526",
+          "annotations": [
+            {
+              "key": "evidence",
+              "value": "gomodel:6197061700003523/6197061700003537",
+              "value-type": "IRI"
+            },
+            {
+              "key": "contributor",
+              "value": "https://orcid.org/0000-0001-7476-6306"
+            },
+            {
+              "key": "date",
+              "value": "2021-12-08"
+            },
+            {
+              "key": "providedBy",
+              "value": "http://informatics.jax.org"
+            }
+          ]
+        },
+        {
+          "subject": "gomodel:6197061700003523/6197061700003525",
+          "property": "RO:0002629",
+          "property-label": "RO:0002629",
+          "object": "gomodel:6197061700003523/6197061700003531",
+          "annotations": [
+            {
+              "key": "evidence",
+              "value": "gomodel:6197061700003523/6197061700003539",
+              "value-type": "IRI"
+            },
+            {
+              "key": "contributor",
+              "value": "https://orcid.org/0000-0001-7476-6306"
+            },
+            {
+              "key": "date",
+              "value": "2023-03-16"
+            },
+            {
+              "key": "providedBy",
+              "value": "http://informatics.jax.org"
+            },
+            {
+              "key": "comment",
+              "value": "Automated change 2023-03-16: RO:0002213 replaced by RO:0002629"
+            }
+          ]
+        },
+        {
+          "subject": "gomodel:6197061700003523/6197061700003531",
+          "property": "RO:0002333",
+          "property-label": "RO:0002333",
+          "object": "gomodel:6197061700003523/6197061700003530",
+          "annotations": [
+            {
+              "key": "evidence",
+              "value": "gomodel:6197061700003523/6197061700003540",
+              "value-type": "IRI"
+            },
+            {
+              "key": "contributor",
+              "value": "https://orcid.org/0000-0001-7476-6306"
+            },
+            {
+              "key": "date",
+              "value": "2021-12-08"
+            },
+            {
+              "key": "providedBy",
+              "value": "http://informatics.jax.org"
+            }
+          ]
+        },
+        {
+          "subject": "gomodel:6197061700003523/6197061700003531",
+          "property": "BFO:0000050",
+          "property-label": "BFO:0000050",
+          "object": "gomodel:6197061700003523/6197061700003526",
+          "annotations": [
+            {
+              "key": "evidence",
+              "value": "gomodel:6197061700003523/6197061700003542",
+              "value-type": "IRI"
+            },
+            {
+              "key": "contributor",
+              "value": "https://orcid.org/0000-0001-7476-6306"
+            },
+            {
+              "key": "date",
+              "value": "2021-12-08"
+            },
+            {
+              "key": "providedBy",
+              "value": "http://informatics.jax.org"
+            }
+          ]
+        },
+        {
+          "subject": "gomodel:6197061700003523/6197061700003525",
+          "property": "BFO:0000066",
+          "property-label": "BFO:0000066",
+          "object": "gomodel:6197061700003523/6197061700003527",
+          "annotations": [
+            {
+              "key": "evidence",
+              "value": "gomodel:6197061700003523/6197061700003538",
+              "value-type": "IRI"
+            },
+            {
+              "key": "contributor",
+              "value": "https://orcid.org/0000-0001-7476-6306"
+            },
+            {
+              "key": "date",
+              "value": "2021-12-08"
+            },
+            {
+              "key": "providedBy",
+              "value": "http://informatics.jax.org"
+            }
+          ]
+        },
+        {
+          "subject": "gomodel:6197061700003523/6197061700003529",
+          "property": "RO:0002629",
+          "property-label": "RO:0002629",
+          "object": "gomodel:6197061700003523/6197061700003525",
+          "annotations": [
+            {
+              "key": "evidence",
+              "value": "gomodel:6197061700003523/6197061700003534",
+              "value-type": "IRI"
+            },
+            {
+              "key": "contributor",
+              "value": "https://orcid.org/0000-0001-7476-6306"
+            },
+            {
+              "key": "date",
+              "value": "2023-03-16"
+            },
+            {
+              "key": "providedBy",
+              "value": "http://informatics.jax.org"
+            },
+            {
+              "key": "comment",
+              "value": "Automated change 2023-03-16: RO:0002213 replaced by RO:0002629"
+            }
+          ]
+        }
+      ],
+      "annotations": [
+        {
+          "key": "state",
+          "value": "production"
+        },
+        {
+          "key": "contributor",
+          "value": "https://orcid.org/0000-0001-7476-6306"
+        },
+        {
+          "key": "date",
+          "value": "2023-03-16"
+        },
+        {
+          "key": "title",
+          "value": "ERBB2-ERBB3 signaling pathway 1 (Mouse)"
+        },
+        {
+          "key": "providedBy",
+          "value": "http://informatics.jax.org"
+        },
+        {
+          "key": "comment",
+          "value": "Automated change 2022-09-22: GO:0044214 replaced by GO:0005886"
+        },
+        {
+          "key": "comment",
+          "value": "Automated change 2023-03-16: RO:0002213 replaced by RO:0002629"
+        },
+        {
+          "key": "https://w3id.org/biolink/vocab/in_taxon",
+          "value": "NCBITaxon:10090",
+          "value-type": "IRI"
+        }
+      ]
+    }
+  </script>
+
+  <script>
+    customElements.whenDefined('wc-gocam-viz').then(function () {
+      const model = JSON.parse(document.getElementById("data").text)
+      const vizElement = document.getElementById("gocam-1")
+      vizElement.setModelData(model)
+    })
+  </script>
+
+</body>
+</html>

--- a/src/styled.html
+++ b/src/styled.html
@@ -60,12 +60,6 @@
     <wc-gocam-viz
       id='gocam-1'
       gocam-id='568b0f9600000284'
-      show-go-cam-selector='true'
-      show-has-input='true'
-      show-has-output='true'
-      show-gene-product='true'
-      show-activity='true'
-      show-isolated-activity='true'
       show-legend='true'
     >
     </wc-gocam-viz>


### PR DESCRIPTION
Fixes #19 

These changes:

* Prevent automatic data fetching when the `gocamId` prop is not provided to `wc-gocam-viz`. Previously the request simply would have failed.
* Allow a `wc-gocam-viz` host to pass data directly to it via the new `setModelData` method.
* Fix a race condition in initializing `dbxrefs`. This didn't really surface when the widget always made a request to get the GO-CAM data because that request generally takes much longer than the network request made while initializing `dbxrefs`. But when the GO-CAM data is already available and provided by the host page the race condition was much more evident. 
* Remove old props (`show-gene-product`, `show-activity`) which were removed from `wc-gocam-viz` some time ago from all examples.

The combination of the first two items allows host pages that already have the GO-CAM data available to simple reuse that instead of making a redundant network request. This will be useful for AmiGO in particular. The new demo/dev page `src/local-data.html` shows an example of how it works.

The linked issue also talks about the possibility of asking the widget for data that it automatically fetched. But the more I thought about it, the less I saw a clear use case for that. With these changes the rule is clear: if the host page wants the data, it should get the data itself and pass the response to the widget in addition to anything else it want to do with the response.