### PR TITLE
Optional chaining of cy within invalidateCoordsCache.

### DIFF
--- a/src/components/gocam-viz/gocam-viz.tsx
+++ b/src/components/gocam-viz/gocam-viz.tsx
@@ -841,7 +841,7 @@ export class GoCamViz {
         // [1] https://github.com/cytoscape/cytoscape.js/blob/3.16.x/src/extensions/renderer/base/load-listeners.js#L326-L342
         // [2] https://github.com/cytoscape/cytoscape.js/issues/3133
         let element: Node = this.gocamviz;
-        const invalidateCoordsCache = () => this.cy.renderer().invalidateContainerClientCoordsCache();
+        const invalidateCoordsCache = () => this.cy?.renderer().invalidateContainerClientCoordsCache();
         while (element != null) {
           element.addEventListener('transitionend', invalidateCoordsCache);
           element.addEventListener('animationend', invalidateCoordsCache);


### PR DESCRIPTION
When incorporating this wc into the uniprot.org website I encountered the following error many times:
```
Uncaught TypeError: Cannot read properties of undefined (reading 'renderer') at HTMLDivElement.invalidateCoordsCache (go-loading-spinner_4.entry.js:77903:49)
```
Optionally chaining `cy` resolves this.