### PR TITLE
Expose more styling to consumer

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -75,18 +75,7 @@ declare global {
         prototype: HTMLGoLoadingSpinnerElement;
         new (): HTMLGoLoadingSpinnerElement;
     };
-    interface HTMLWcGenesPanelElementEventMap {
-        "selectChanged": any;
-    }
     interface HTMLWcGenesPanelElement extends Components.WcGenesPanel, HTMLStencilElement {
-        addEventListener<K extends keyof HTMLWcGenesPanelElementEventMap>(type: K, listener: (this: HTMLWcGenesPanelElement, ev: WcGenesPanelCustomEvent<HTMLWcGenesPanelElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-        removeEventListener<K extends keyof HTMLWcGenesPanelElementEventMap>(type: K, listener: (this: HTMLWcGenesPanelElement, ev: WcGenesPanelCustomEvent<HTMLWcGenesPanelElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLWcGenesPanelElement: {
         prototype: HTMLWcGenesPanelElement;
@@ -98,38 +87,13 @@ declare global {
         prototype: HTMLWcGocamLegendElement;
         new (): HTMLWcGocamLegendElement;
     };
-    interface HTMLWcGocamSelectorElementEventMap {
-        "selectGOCAM": any;
-    }
     interface HTMLWcGocamSelectorElement extends Components.WcGocamSelector, HTMLStencilElement {
-        addEventListener<K extends keyof HTMLWcGocamSelectorElementEventMap>(type: K, listener: (this: HTMLWcGocamSelectorElement, ev: WcGocamSelectorCustomEvent<HTMLWcGocamSelectorElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-        removeEventListener<K extends keyof HTMLWcGocamSelectorElementEventMap>(type: K, listener: (this: HTMLWcGocamSelectorElement, ev: WcGocamSelectorCustomEvent<HTMLWcGocamSelectorElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLWcGocamSelectorElement: {
         prototype: HTMLWcGocamSelectorElement;
         new (): HTMLWcGocamSelectorElement;
     };
-    interface HTMLWcGocamVizElementEventMap {
-        "nodeOver": any;
-        "nodeOut": any;
-        "nodeClick": any;
-        "layoutChange": any;
-    }
     interface HTMLWcGocamVizElement extends Components.WcGocamViz, HTMLStencilElement {
-        addEventListener<K extends keyof HTMLWcGocamVizElementEventMap>(type: K, listener: (this: HTMLWcGocamVizElement, ev: WcGocamVizCustomEvent<HTMLWcGocamVizElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-        removeEventListener<K extends keyof HTMLWcGocamVizElementEventMap>(type: K, listener: (this: HTMLWcGocamVizElement, ev: WcGocamVizCustomEvent<HTMLWcGocamVizElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLWcGocamVizElement: {
         prototype: HTMLWcGocamVizElement;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -75,7 +75,18 @@ declare global {
         prototype: HTMLGoLoadingSpinnerElement;
         new (): HTMLGoLoadingSpinnerElement;
     };
+    interface HTMLWcGenesPanelElementEventMap {
+        "selectChanged": any;
+    }
     interface HTMLWcGenesPanelElement extends Components.WcGenesPanel, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLWcGenesPanelElementEventMap>(type: K, listener: (this: HTMLWcGenesPanelElement, ev: WcGenesPanelCustomEvent<HTMLWcGenesPanelElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLWcGenesPanelElementEventMap>(type: K, listener: (this: HTMLWcGenesPanelElement, ev: WcGenesPanelCustomEvent<HTMLWcGenesPanelElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLWcGenesPanelElement: {
         prototype: HTMLWcGenesPanelElement;
@@ -87,13 +98,38 @@ declare global {
         prototype: HTMLWcGocamLegendElement;
         new (): HTMLWcGocamLegendElement;
     };
+    interface HTMLWcGocamSelectorElementEventMap {
+        "selectGOCAM": any;
+    }
     interface HTMLWcGocamSelectorElement extends Components.WcGocamSelector, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLWcGocamSelectorElementEventMap>(type: K, listener: (this: HTMLWcGocamSelectorElement, ev: WcGocamSelectorCustomEvent<HTMLWcGocamSelectorElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLWcGocamSelectorElementEventMap>(type: K, listener: (this: HTMLWcGocamSelectorElement, ev: WcGocamSelectorCustomEvent<HTMLWcGocamSelectorElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLWcGocamSelectorElement: {
         prototype: HTMLWcGocamSelectorElement;
         new (): HTMLWcGocamSelectorElement;
     };
+    interface HTMLWcGocamVizElementEventMap {
+        "nodeOver": any;
+        "nodeOut": any;
+        "nodeClick": any;
+        "layoutChange": any;
+    }
     interface HTMLWcGocamVizElement extends Components.WcGocamViz, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLWcGocamVizElementEventMap>(type: K, listener: (this: HTMLWcGocamVizElement, ev: WcGocamVizCustomEvent<HTMLWcGocamVizElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLWcGocamVizElementEventMap>(type: K, listener: (this: HTMLWcGocamVizElement, ev: WcGocamVizCustomEvent<HTMLWcGocamVizElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLWcGocamVizElement: {
         prototype: HTMLWcGocamVizElement;

--- a/src/components/genes-panel/genes-panel.scss
+++ b/src/components/genes-panel/genes-panel.scss
@@ -22,6 +22,7 @@
    * @prop --activity-border-width: Border width of activity containers
    * @prop --activity-color: Text color of activity containers
    * @prop --activity-color-active: Text color of activity containers when highlighted
+   * @prop activity-color-active-link-hover: Hover anchor link color within activity containers when highlighted
    * @prop --activity-padding: Padding of activity containers
    *
    * @prop --gene-product-background: Background of gene product labels
@@ -74,6 +75,10 @@
   a {
     color: var(--activity-color);
     text-decoration: none;
+
+    &:hover {
+      color: var(--activity-color-link-hover);
+    }
   }
 
   &.active {

--- a/src/components/genes-panel/genes-panel.scss
+++ b/src/components/genes-panel/genes-panel.scss
@@ -22,7 +22,7 @@
    * @prop --activity-border-width: Border width of activity containers
    * @prop --activity-color: Text color of activity containers
    * @prop --activity-color-active: Text color of activity containers when highlighted
-   * @prop activity-color-active-link-hover: Hover anchor link color within activity containers when highlighted
+   * @prop --activity-color-active-link-hover: Hover anchor link color within activity containers when highlighted
    * @prop --activity-padding: Padding of activity containers
    *
    * @prop --gene-product-background: Background of gene product labels

--- a/src/components/genes-panel/genes-panel.scss
+++ b/src/components/genes-panel/genes-panel.scss
@@ -41,6 +41,7 @@
    * @prop --node-border-width: Border width of related node info
    * @prop --node-color: Text color of related node info
    * @prop --node-padding: Padding of related node info
+   * @prop --node-align-items: Align-items of related node info
    *
    * @prop --function-nodes-padding: Padding of related nodes container
    */
@@ -107,7 +108,7 @@
 
 .node {
   display: flex;
-  align-items: center;
+  align-items: var(--node-align-items, center);
   margin-bottom: 0.175em;
   width: 100%;
   @include standard-var-styles(node);

--- a/src/components/genes-panel/genes-panel.tsx
+++ b/src/components/genes-panel/genes-panel.tsx
@@ -4,6 +4,7 @@ import { Activity, ActivityNode, Cam, Evidence, noctuaFormConfig } from '../../g
 
 /**
  * @part process - Process containers
+ * @part process-label - Process label
  * @part activity - Activity containers
  * @part gene-product - Gene product labels
  * @part function-label - Molecular function labels
@@ -154,7 +155,7 @@ export class GenesPanel {
 
         return (
             <div class="process" part="process">
-                <div class="process-label">
+                <div class="process-label" part="process-label">
                     {process}
                 </div>
                 <div class="process-activities">

--- a/src/components/genes-panel/readme.md
+++ b/src/components/genes-panel/readme.md
@@ -24,12 +24,6 @@
 
 
 
-#### Parameters
-
-| Name     | Type  | Description |
-| -------- | ----- | ----------- |
-| `nodeId` | `any` |             |
-
 #### Returns
 
 Type: `Promise<void>`

--- a/src/components/genes-panel/readme.md
+++ b/src/components/genes-panel/readme.md
@@ -1,7 +1,5 @@
 # wc-genes-panel
 
-
-
 <!-- Auto Generated Below -->
 
 
@@ -26,6 +24,12 @@
 
 
 
+#### Parameters
+
+| Name     | Type  | Description |
+| -------- | ----- | ----------- |
+| `nodeId` | `any` |             |
+
 #### Returns
 
 Type: `Promise<void>`
@@ -41,6 +45,7 @@ Type: `Promise<void>`
 | `"function-label"` | Molecular function labels |
 | `"gene-product"`   | Gene product labels       |
 | `"process"`        | Process containers        |
+| `"process-label"`  | Process label             |
 
 
 ## CSS Custom Properties
@@ -66,6 +71,7 @@ Type: `Promise<void>`
 | `--gene-product-color`          | Text color of gene product labels                  |
 | `--gene-product-padding`        | Padding of gene product labels                     |
 | `--height`                      | Height of the panel                                |
+| `--node-align-items`            | Align-items of related node info                   |
 | `--node-background`             | Background of related node info                    |
 | `--node-border-color`           | Border color of related node info                  |
 | `--node-border-width`           | Border width of related node info                  |

--- a/src/components/genes-panel/readme.md
+++ b/src/components/genes-panel/readme.md
@@ -50,43 +50,44 @@ Type: `Promise<void>`
 
 ## CSS Custom Properties
 
-| Name                            | Description                                        |
-| ------------------------------- | -------------------------------------------------- |
-| `--activity-background`         | Background of activity containers                  |
-| `--activity-background-active`  | Background of activity containers when highlighted |
-| `--activity-border-color`       | Border color of activity containers                |
-| `--activity-border-width`       | Border width of activity containers                |
-| `--activity-color`              | Text color of activity containers                  |
-| `--activity-color-active`       | Text color of activity containers when highlighted |
-| `--activity-padding`            | Padding of activity containers                     |
-| `--function-label-background`   | Background of molecular function term labels       |
-| `--function-label-border-color` | Border color of molecular function term labels     |
-| `--function-label-border-width` | Border width of molecular function term labels     |
-| `--function-label-color`        | Text color of molecular function term labels       |
-| `--function-label-padding`      | Padding of molecular function term labels          |
-| `--function-nodes-padding`      | Padding of related nodes container                 |
-| `--gene-product-background`     | Background of gene product labels                  |
-| `--gene-product-border-color`   | Border color of gene product labels                |
-| `--gene-product-border-width`   | Border width of gene product labels                |
-| `--gene-product-color`          | Text color of gene product labels                  |
-| `--gene-product-padding`        | Padding of gene product labels                     |
-| `--height`                      | Height of the panel                                |
-| `--node-align-items`            | Align-items of related node info                   |
-| `--node-background`             | Background of related node info                    |
-| `--node-border-color`           | Border color of related node info                  |
-| `--node-border-width`           | Border width of related node info                  |
-| `--node-color`                  | Text color of related node info                    |
-| `--node-padding`                | Padding of related node info                       |
-| `--process-background`          | Background of process containers                   |
-| `--process-border-color`        | Border color of process containers                 |
-| `--process-border-width`        | Border width of process containers                 |
-| `--process-color`               | Text color of process containers                   |
-| `--process-label-background`    | Background of process labels                       |
-| `--process-label-border-color`  | Border color of process labels                     |
-| `--process-label-border-width`  | Border width of process labels                     |
-| `--process-label-color`         | Text color of process labels                       |
-| `--process-label-padding`       | Padding of process labels                          |
-| `--process-padding`             | Padding of process containers                      |
+| Name                                 | Description                                                         |
+| ------------------------------------ | ------------------------------------------------------------------- |
+| `--activity-background`              | Background of activity containers                                   |
+| `--activity-background-active`       | Background of activity containers when highlighted                  |
+| `--activity-border-color`            | Border color of activity containers                                 |
+| `--activity-border-width`            | Border width of activity containers                                 |
+| `--activity-color`                   | Text color of activity containers                                   |
+| `--activity-color-active`            | Text color of activity containers when highlighted                  |
+| `--activity-color-active-link-hover` | Hover anchor link color within activity containers when highlighted |
+| `--activity-padding`                 | Padding of activity containers                                      |
+| `--function-label-background`        | Background of molecular function term labels                        |
+| `--function-label-border-color`      | Border color of molecular function term labels                      |
+| `--function-label-border-width`      | Border width of molecular function term labels                      |
+| `--function-label-color`             | Text color of molecular function term labels                        |
+| `--function-label-padding`           | Padding of molecular function term labels                           |
+| `--function-nodes-padding`           | Padding of related nodes container                                  |
+| `--gene-product-background`          | Background of gene product labels                                   |
+| `--gene-product-border-color`        | Border color of gene product labels                                 |
+| `--gene-product-border-width`        | Border width of gene product labels                                 |
+| `--gene-product-color`               | Text color of gene product labels                                   |
+| `--gene-product-padding`             | Padding of gene product labels                                      |
+| `--height`                           | Height of the panel                                                 |
+| `--node-align-items`                 | Align-items of related node info                                    |
+| `--node-background`                  | Background of related node info                                     |
+| `--node-border-color`                | Border color of related node info                                   |
+| `--node-border-width`                | Border width of related node info                                   |
+| `--node-color`                       | Text color of related node info                                     |
+| `--node-padding`                     | Padding of related node info                                        |
+| `--process-background`               | Background of process containers                                    |
+| `--process-border-color`             | Border color of process containers                                  |
+| `--process-border-width`             | Border width of process containers                                  |
+| `--process-color`                    | Text color of process containers                                    |
+| `--process-label-background`         | Background of process labels                                        |
+| `--process-label-border-color`       | Border color of process labels                                      |
+| `--process-label-border-width`       | Border width of process labels                                      |
+| `--process-label-color`              | Text color of process labels                                        |
+| `--process-label-padding`            | Padding of process labels                                           |
+| `--process-padding`                  | Padding of process containers                                       |
 
 
 ## Dependencies

--- a/src/components/gocam-viz/gocam-viz.scss
+++ b/src/components/gocam-viz/gocam-viz.scss
@@ -73,6 +73,7 @@
    * @prop --node-border-width: Border width of related node info in processes and activities panel
    * @prop --node-color: Text color of related node info in processes and activities panel
    * @prop --node-padding: Padding of related node info in processes and activities panel
+   * @prop --node-align-items: Align-items of related node info
    *
    * @prop --function-nodes-padding: Padding of related nodes container in processes and activities panel
    */

--- a/src/components/gocam-viz/gocam-viz.scss
+++ b/src/components/gocam-viz/gocam-viz.scss
@@ -53,6 +53,7 @@
    * @prop --activity-border-color: Border color of activity containers in processes and activities panel
    * @prop --activity-border-width: Border width of activity containers in processes and activities panel
    * @prop --activity-color: Text color of activity containers in processes and activities panel
+   * @prop --activity-color-link-hover: Anchor link hover color in processes and activities panel
    * @prop --activity-color-active: Text color of activity containers in processes and activities panel when highlighted
    * @prop --activity-padding: Padding of activity containers in processes and activities panel
    *

--- a/src/components/gocam-viz/gocam-viz.tsx
+++ b/src/components/gocam-viz/gocam-viz.tsx
@@ -24,6 +24,7 @@ const GOMODEL_PREFIX = "gomodel:"
  * @part gocam-graph - The GO-CAM graph container
  * @part activities-panel - The panel containing the process and activities list
  * @part process - A process group in the process and activities list
+ * @part process-label - A process label in the process and activities list
  * @part activity - An activity in the process and activities list
  * @part gene-product - A gene product name in process and activities list
  * @part function-label - A function term name in process and activities list
@@ -781,7 +782,7 @@ export class GoCamViz {
                         <div class="panel-body">
                             <wc-genes-panel
                                 cam={this.cam}
-                                exportparts="process, activity, gene-product, function-label"
+                                exportparts="process, process-label, activity, gene-product, function-label"
                                 ref={el => this.genesPanel = el}
                             >
                             </wc-genes-panel>

--- a/src/components/gocam-viz/readme.md
+++ b/src/components/gocam-viz/readme.md
@@ -38,12 +38,6 @@ Type: `Promise<void>`
 
 Define if the GO-CAM viz should capture the mouse scroll
 
-#### Parameters
-
-| Name       | Type  | Description                                                            |
-| ---------- | ----- | ---------------------------------------------------------------------- |
-| `shouldAF` | `any` | set to true if you want a mouse scroll to be captured by the component |
-
 #### Returns
 
 Type: `Promise<void>`
@@ -54,12 +48,6 @@ Type: `Promise<void>`
 
 Manually supply GO-CAM data to be rendered. This will overwrite any data previously
 fetched using the gocamId and apiUrl props, if they were provided.
-
-#### Parameters
-
-| Name    | Type  | Description   |
-| ------- | ----- | ------------- |
-| `model` | `any` | GO-CAM object |
 
 #### Returns
 

--- a/src/components/gocam-viz/readme.md
+++ b/src/components/gocam-viz/readme.md
@@ -1,7 +1,5 @@
 # wc-gocam-viz
 
-
-
 <!-- Auto Generated Below -->
 
 
@@ -108,6 +106,7 @@ Type: `Promise<void>`
 | `--activity-border-width`       | Border width of activity containers in processes and activities panel                |
 | `--activity-color`              | Text color of activity containers in processes and activities panel                  |
 | `--activity-color-active`       | Text color of activity containers in processes and activities panel when highlighted |
+| `--activity-color-link-hover`   | Anchor link hover color in processes and activities panel                            |
 | `--activity-padding`            | Padding of activity containers in processes and activities panel                     |
 | `--border-color`                | Default color of various borders used in the widget                                  |
 | `--button-background`           | Background of buttons in widget                                                      |

--- a/src/components/gocam-viz/readme.md
+++ b/src/components/gocam-viz/readme.md
@@ -40,6 +40,12 @@ Type: `Promise<void>`
 
 Define if the GO-CAM viz should capture the mouse scroll
 
+#### Parameters
+
+| Name       | Type  | Description                                                            |
+| ---------- | ----- | ---------------------------------------------------------------------- |
+| `shouldAF` | `any` | set to true if you want a mouse scroll to be captured by the component |
+
 #### Returns
 
 Type: `Promise<void>`
@@ -50,6 +56,12 @@ Type: `Promise<void>`
 
 Manually supply GO-CAM data to be rendered. This will overwrite any data previously
 fetched using the gocamId and apiUrl props, if they were provided.
+
+#### Parameters
+
+| Name    | Type  | Description   |
+| ------- | ----- | ------------- |
+| `model` | `any` | GO-CAM object |
 
 #### Returns
 
@@ -83,6 +95,7 @@ Type: `Promise<void>`
 | `"legend-section"`   | An individual legend entry                           |
 | `"legend-sections"`  | A group of entries in the legend                     |
 | `"process"`          | A process group in the process and activities list   |
+| `"process-label"`    | A process label in the process and activities list   |
 
 
 ## CSS Custom Properties
@@ -125,6 +138,7 @@ Type: `Promise<void>`
 | `--legend-header-padding`       | Padding of legend header                                                             |
 | `--legend-margin`               | Margin of legend container                                                           |
 | `--legend-padding`              | Padding of legend container                                                          |
+| `--node-align-items`            | Align-items of related node info                                                     |
 | `--node-background`             | Background of related node info in processes and activities panel                    |
 | `--node-border-color`           | Border color of related node info in processes and activities panel                  |
 | `--node-border-width`           | Border width of related node info in processes and activities panel                  |

--- a/src/styled.html
+++ b/src/styled.html
@@ -1,95 +1,87 @@
-<html dir='ltr' lang='en'>
+<html dir="ltr" lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script type="module" src="/build/wc-gocam-viz.esm.js"></script>
+    <script nomodule src="/build/wc-gocam-viz.js"></script>
 
-
-<head>
-  <meta name='viewport' content='width=device-width, initial-scale=1' />
-  <script type='module' src='/build/wc-gocam-viz.esm.js'></script>
-  <script nomodule src='/build/wc-gocam-viz.js'></script>
-
-  <link rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css'>
-  <link rel='stylesheet' href='/reset.css'>
-  <title>wc-gocam-viz -- styled</title>
-  <style>
-    wc-gocam-viz {
-      --panel-border-width: 1px;
-      --panel-header-background: rgba(0, 0, 0, 0.03);
-      --panel-header-padding: 0.5rem 1rem;
-      --panel-header-font-weight: normal;
-      --button-background: #0d6efd;
-      --button-color: white;
-      --button-background-hover: #0b5ed7;
-      --legend-border-width: 1px 0 0 0;
-      --legend-padding: 0.5rem 1rem;
-      --process-label-background: #7a548d;
-      --process-label-color: white;
-      --process-label-padding: 0.5rem 1rem;
-      --process-label-border-width: 0;
-      --activity-border-color: #d1b6df;
-      --activity-border-width: 0 0 3px 0;
-      --activity-background-active: #af732a;
-      --activity-color-active: #eee;
-      --gene-product-color: #333;
-      --gene-product-padding: 0.5rem 1rem;
-      --gene-product-border-width: 0 0 1px 0;
-      --function-label-padding: 0.5rem 1rem;
-      --function-nodes-padding: 0px 1rem 0.5rem 1rem;
-      --node-border-width: 0 0 1px 0;
-      --graph-padding: 1rem;
-    }
-
-    wc-gocam-viz::part(gene-product) {
-      font-size: 1.125rem;
-      font-weight: bold;
-    }
-
-    wc-gocam-viz::part(legend-header) {
-      text-align: center;
-    }
-
-    wc-gocam-viz::part(gocam-title) {
-      font-weight: bold;
-    }
-  </style>
-</head>
-
-
-<body>
-
-  <div style='max-width: 1200px; margin: 0 auto'>
-    <wc-gocam-viz id='gocam-1' gocam-id='568b0f9600000284' show-legend='true'>
-    </wc-gocam-viz>
-  </div>
-
-
-  <!-- OPTIONAL: SPECIAL HANDLING OF EVENTS -->
-  <script>
-    /**
-     * General Key listener, here to recenter the graph visualization
-     */
-    document.addEventListener('keydown', (key) => {
-      if (key.code == 'Space') {
-        key.preventDefault();
-        let viz = document.getElementById('gocam-1');
-        if (viz) {
-          viz.resetView();
-        }
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" />
+    <link rel="stylesheet" href="/reset.css" />
+    <title>wc-gocam-viz -- styled</title>
+    <style>
+      wc-gocam-viz {
+        --panel-border-width: 1px;
+        --panel-header-background: rgba(0, 0, 0, 0.03);
+        --panel-header-padding: 0.5rem 1rem;
+        --panel-header-font-weight: normal;
+        --button-background: #0d6efd;
+        --button-color: white;
+        --button-background-hover: #0b5ed7;
+        --legend-border-width: 1px 0 0 0;
+        --legend-padding: 0.5rem 1rem;
+        --process-label-background: #7a548d;
+        --process-label-color: white;
+        --process-label-padding: 0.5rem 1rem;
+        --process-label-border-width: 0;
+        --activity-border-color: #d1b6df;
+        --activity-border-width: 0 0 3px 0;
+        --activity-background-active: #af732a;
+        --activity-color-active: #eee;
+        --activity-color-link-hover: #eee;
+        --gene-product-color: #333;
+        --gene-product-padding: 0.5rem 1rem;
+        --gene-product-border-width: 0 0 1px 0;
+        --function-label-padding: 0.5rem 1rem;
+        --function-nodes-padding: 0px 1rem 0.5rem 1rem;
+        --node-border-width: 0 0 1px 0;
+        --graph-padding: 1rem;
       }
-    });
 
-    /**
-     * Listen to a mouse over event on an activity node
-     */
-    document.addEventListener('nodeOver', function hideMenu(e, v) {
-      let payload = e.detail;
-    });
+      wc-gocam-viz::part(gene-product) {
+        font-size: 1.125rem;
+        font-weight: bold;
+      }
 
-    /**
-     * Listen to a mouse out event from an activity node
-     */
-    document.addEventListener('nodeOut', function hideMenu(e, v) {
-    });
+      wc-gocam-viz::part(legend-header) {
+        text-align: center;
+      }
 
-  </script>
+      wc-gocam-viz::part(gocam-title) {
+        font-weight: bold;
+      }
+    </style>
+  </head>
 
-</body>
+  <body>
+    <div style="max-width: 1200px; margin: 0 auto">
+      <wc-gocam-viz id="gocam-1" gocam-id="568b0f9600000284" show-legend="true"> </wc-gocam-viz>
+    </div>
+
+    <!-- OPTIONAL: SPECIAL HANDLING OF EVENTS -->
+    <script>
+      /**
+       * General Key listener, here to recenter the graph visualization
+       */
+      document.addEventListener('keydown', key => {
+        if (key.code == 'Space') {
+          key.preventDefault();
+          let viz = document.getElementById('gocam-1');
+          if (viz) {
+            viz.resetView();
+          }
+        }
+      });
+
+      /**
+       * Listen to a mouse over event on an activity node
+       */
+      document.addEventListener('nodeOver', function hideMenu(e, v) {
+        let payload = e.detail;
+      });
+
+      /**
+       * Listen to a mouse out event from an activity node
+       */
+      document.addEventListener('nodeOut', function hideMenu(e, v) {});
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
Exposing more styling via custom properties and parts to consumer. Part of integration into UniProtKB entry pages.

Within Gene Panel:
* `@prop --activity-color-active-link-hover`: Hover anchor link color within activity containers when highlighted
* `@prop -node-align-items`: Align-items of related node info
* `@part process-label`: Process label