### PR TITLE
Prevent empty links

### DIFF
--- a/src/components/genes-panel/genes-panel.scss
+++ b/src/components/genes-panel/genes-panel.scss
@@ -125,6 +125,7 @@
 }
 
 .node-relation {
+  cursor: default;
   font-size: 0.625em;
   @include deep-width(8em);
 }

--- a/src/components/genes-panel/genes-panel.tsx
+++ b/src/components/genes-panel/genes-panel.tsx
@@ -199,7 +199,7 @@ export class GenesPanel {
                                 return (
                                     <div class='node'>
                                         <div class="node-relation">
-                                            <a target='_blank' href="">{node.predicate?.edge.label}</a>
+                                            {node.predicate?.edge.label}
                                         </div>
                                         <div class="node-term">
                                             <a target='_blank' href={node.term.url}>{node.term.label}</a>

--- a/src/components/genes-panel/genes-panel.tsx
+++ b/src/components/genes-panel/genes-panel.tsx
@@ -124,10 +124,10 @@ export class GenesPanel {
             <span>
                 {
                     evidences.map(evidence => {
-                        if (!evidence.reference) {
+                        if (!evidence.reference || !evidence.referenceEntity) {
                             return null; // for extreme case
                         }
-                        return <a href={evidence.referenceEntity?.url} target='_blank'
+                        return <a href={evidence.referenceEntity.url} target='_blank'
                             title={"Source: " + evidence.reference + "\nEvidence: " + evidence.evidence.label}>
                             {this.renderReferenceIcon()}
                         </a>


### PR DESCRIPTION
Noticed a few empty links

1. The node relations:

```
<div class="node-relation">
  <a target="_blank" href="">part of</a>
</div>
```

which causes a new tab to open with the address of where the wc-gocam-viz is currently embedded.

2. I saw optional chaining on `evidence.referenceEntity` so thought best to bail early to prevent empty href there.