### PR TITLE
Remove unnecessary default padding on function label and node containers

### DIFF
--- a/src/components/gocam-viz/gocam-viz.scss
+++ b/src/components/gocam-viz/gocam-viz.scss
@@ -114,9 +114,9 @@
 
   @include standard-var-declarations(gene-product, $border-color: var(--border-color));
 
-  @include standard-var-declarations(function-label, $border-color: var(--border-color), $padding: 0 1em 0 0);
+  @include standard-var-declarations(function-label, $border-color: var(--border-color));
 
-  @include standard-var-declarations(node, $border-color: var(--border-color), $padding: 0 1em 0 0);
+  @include standard-var-declarations(node, $border-color: var(--border-color));
 
   --function-nodes-padding: 0;
 }


### PR DESCRIPTION
I'm not sure why these elements had default padding applied to them, but it was causing the evidence icons to be misaligned and making the panel scroll horizontally by default.

| Before | After |
| --- | --- |
| <img width="416" alt="image" src="https://github.com/user-attachments/assets/20983e6e-146e-4049-a106-52dbec411e9d" /> | <img width="416" alt="image" src="https://github.com/user-attachments/assets/f361614d-d66b-4cc7-aa1a-e1af9f495e9d" /> |
