### PR TITLE
Render evidence icon in a span when URL not available

### DIFF
--- a/src/components/genes-panel/genes-panel.tsx
+++ b/src/components/genes-panel/genes-panel.tsx
@@ -124,13 +124,29 @@ export class GenesPanel {
             <span>
                 {
                     evidences.map(evidence => {
-                        if (!evidence.reference || !evidence.referenceEntity) {
+                        if (!evidence.reference) {
                             return null; // for extreme case
                         }
-                        return <a href={evidence.referenceEntity.url} target='_blank'
-                            title={"Source: " + evidence.reference + "\nEvidence: " + evidence.evidence.label}>
-                            {this.renderReferenceIcon()}
-                        </a>
+                        const elementTitle = "Source: " + evidence.reference + "\nEvidence: " + evidence.evidence.label;
+                        if (evidence.referenceEntity?.url) {
+                            return (
+                                <a
+                                    href={evidence.referenceEntity.url}
+                                    target='_blank'
+                                    title={elementTitle}
+                                >
+                                    {this.renderReferenceIcon()}
+                              </a>
+                            )
+                        } else {
+                            return (
+                                <span
+                                    title={elementTitle}
+                                >
+                                    {this.renderReferenceIcon()}
+                                </span>
+                            )
+                        }
                     })
                 }
             </span>


### PR DESCRIPTION
Fixes #81 

Without wading into the whole `dbxrefs` miasma and whether or not there are issues with the stability of the server it talks to, I think these changes address the basic concern:

1. In the case that an `evidence` instance has a `referenceEntity` which in turn has a `url`, then render the reference icon as a link.
2. Otherwise, render the reference icon in a `<span>`. This prevents having an `<a>` without a valid `href` attribute.